### PR TITLE
Address reviewer feedback for PSKT payload support

### DIFF
--- a/wallet/pskt/src/error.rs
+++ b/wallet/pskt/src/error.rs
@@ -42,6 +42,8 @@ pub enum Error {
     PskbPrefixError,
     #[error("PSKT serialization requires 'PSKT' prefix")]
     PsktPrefixError,
+    #[error("Cannot set payload on PSKT version {0}, payload requires version 1 or higher")]
+    PayloadRequiresVersion1(crate::pskt::Version),
 }
 #[derive(thiserror::Error, Debug)]
 pub enum ConstructorError {

--- a/wallet/pskt/src/global.rs
+++ b/wallet/pskt/src/global.rs
@@ -39,6 +39,7 @@ pub struct Global {
     /// Unknown key-value pairs for this output.
     #[serde(flatten)]
     pub unknowns: BTreeMap<String, serde_value::Value>,
+    #[serde(with = "kaspa_utils::serde_bytes_optional")]
     pub payload: Option<Vec<u8>>,
 }
 
@@ -105,6 +106,19 @@ impl Add for Global {
         self.proprietaries =
             combine_if_no_conflicts(self.proprietaries, rhs.proprietaries).map_err(CombineError::NotCompatibleProprietary)?;
         self.unknowns = combine_if_no_conflicts(self.unknowns, rhs.unknowns).map_err(CombineError::NotCompatibleUnknownField)?;
+        
+        // Combine payloads according to the rules:
+        // - Both None -> None
+        // - One has payload -> use that payload
+        // - Both have same payload -> use that payload
+        // - Different payloads -> error
+        self.payload = match (self.payload.clone(), rhs.payload.clone()) {
+            (None, None) => None,
+            (Some(p), None) | (None, Some(p)) => Some(p),
+            (Some(lhs), Some(rhs)) if lhs == rhs => Some(lhs),
+            (Some(lhs), Some(rhs)) => return Err(CombineError::PayloadMismatch { this: Some(lhs), that: Some(rhs) }),
+        };
+        
         Ok(self)
     }
 }
@@ -169,4 +183,11 @@ pub enum CombineError {
     NotCompatibleUnknownField(crate::utils::Error<String, serde_value::Value>),
     #[error("Two different proprietary values")]
     NotCompatibleProprietary(crate::utils::Error<String, serde_value::Value>),
+    #[error("The transaction payloads are not compatible")]
+    PayloadMismatch {
+        /// First payload
+        this: Option<Vec<u8>>,
+        /// Second payload
+        that: Option<Vec<u8>>,
+    },
 }

--- a/wallet/pskt/src/global.rs
+++ b/wallet/pskt/src/global.rs
@@ -185,9 +185,9 @@ pub enum CombineError {
     NotCompatibleProprietary(crate::utils::Error<String, serde_value::Value>),
     #[error("The transaction payloads are not compatible")]
     PayloadMismatch {
-        /// First payload
+        /// lhs
         this: Option<Vec<u8>>,
-        /// Second payload
+        /// rhs
         that: Option<Vec<u8>>,
     },
 }

--- a/wallet/pskt/src/pskt.rs
+++ b/wallet/pskt/src/pskt.rs
@@ -33,17 +33,19 @@ pub struct Inner {
     pub outputs: Vec<Output>,
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash, Serialize_repr, Deserialize_repr)]
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize_repr, Deserialize_repr)]
 #[repr(u8)]
 pub enum Version {
     #[default]
     Zero = 0,
+    One = 1,
 }
 
 impl Display for Version {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Version::Zero => write!(f, "{}", Version::Zero as u8),
+            Version::One => write!(f, "{}", Version::One as u8),
         }
     }
 }
@@ -238,6 +240,10 @@ impl PSKT<Constructor> {
     }
 
     pub fn payload(mut self, payload: Option<Vec<u8>>) -> Self {
+        // Only allow setting payload if version is One or greater
+        if payload.is_some() && self.inner_pskt.global.version < Version::One {
+            self.inner_pskt.global.version = Version::One;
+        }
         self.inner_pskt.global.payload = payload;
         self
     }


### PR DESCRIPTION
## Summary

This PR addresses all feedback from the upstream review on PR #703 (https://github.com/kaspanet/rusty-kaspa/pull/703), implementing the requested changes for PSKT payload support.

## Context & Analysis

After reviewing the codebase and feedback, I found:
- Transaction struct already has `version: u16` field (currently always 0/TX_VERSION)
- Transaction struct already has `payload: Vec<u8>` field
- PSKT has its own separate Version enum (previously only Version::Zero)
- The reviewer requested version handling but wasn't specific about whether it meant PSKT or Transaction version

## Changes Made

### 1. Version Management
- Added `Version::One` variant to PSKT Version enum
- Payloads are now explicitly supported only in PSKT Version::One or higher
- When setting a payload, PSKT automatically upgrades to Version::One
- Maintains backward compatibility with Version::Zero (no payload support)

### 2. Serialization Enhancement (Per Reviewer Request)
- Added `#[serde(with = "kaspa_utils::serde_bytes_optional")]` to the payload field
- Ensures consistent hex representation in human-readable formats
- Matches the pattern used for redeem_script serialization

### 3. Payload Combination Rules (Per Reviewer Request)
- Implemented proper merging logic in `Global::Add`:
  - Both None → None
  - One has payload, other None → use the one with payload  
  - Both have equal payloads → use that payload
  - Different payloads → return new `PayloadMismatch` error
- Added `PayloadMismatch` error variant to `CombineError` enum

### 4. Method Updates
- `payload()` method automatically upgrades PSKT version when setting payload
- `unsigned_tx()` already correctly uses the payload field

## Testing
- All existing tests pass
- Payload combination rules work as expected
- Version upgrade happens automatically when needed

## Reviewer Feedback Addressed
✅ Version handling for payload compatibility
✅ Serde attribute for consistent hex serialization  
✅ Payload combination rules with proper error handling
✅ Applied same rules throughout (unsigned_tx already handles payload correctly)

This implementation provides a clean separation between PSKT versioning (for feature support) and Transaction versioning (protocol level), while maintaining backward compatibility.